### PR TITLE
Set open_issues explicit

### DIFF
--- a/src/jquery.github.js
+++ b/src/jquery.github.js
@@ -7,6 +7,7 @@ function GithubRepo( repo ) {
 	this.pushed_at = repo.pushed_at;
 	this.url = repo.url;
 	this.watchers = repo.watchers;
+    this.open_issues = repo.open_issues;
 }
 
 // Parses HTML template


### PR DESCRIPTION
When issues are enabled (iconIssues: **true**), not the number of issues which are currently open are displayed but only the string 'undefined'. This was because the variable _open_issues_ was never explicit set.

This pull request proposes a commit which fixes this.
