### PR TITLE
Display options won't work without cache

### DIFF
--- a/src/jquery.github.js
+++ b/src/jquery.github.js
@@ -67,7 +67,6 @@ function Github( element, options ) {
 	this._defaults = defaults;
 
 	this.init();
-	this.displayIcons();
 }
 
 // Initializer
@@ -151,6 +150,8 @@ Github.prototype.applyTemplate = function ( repo ) {
 		$widget = githubRepo.toHTML();
 
 	$widget.appendTo( this.$container );
+
+	this.displayIcons();
 };
 
 // -- Attach plugin to jQuery's prototype --------------------------------------


### PR DESCRIPTION
`Github.diplayIcons` was being called immediately after `Github.init` on the constructor, which wouldn't work at first load because of the async request to the Github API. Moving it to `Github.applyTemplate` ensures it will always be called after a template update.